### PR TITLE
Add newly open-sourced PostgreSQL extension Spock under High-Availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 * [autobase](https://github.com/vitabaks/autobase) - Autobase for PostgreSQL® is an open-source DBaaS that automates the deployment and management of highly available PostgreSQL clusters.
 * [BDR](https://github.com/2ndQuadrant/bdr) - BiDirectional Replication - a multimaster replication system for PostgreSQL
 * [Patroni](https://github.com/zalando/patroni) - Template for PostgreSQL HA with ZooKeeper or etcd.
+* [Spock](https://github.com/pgEdge/spock) - 100% open-source logical multi-master PostgreSQL replication.
 * [Stolon](https://github.com/sorintlab/stolon) - PostgreSQL HA based on Consul or etcd, with Kubernetes integration.
 * [pglookout](https://github.com/aiven/pglookout) - Replication monitoring and failover daemon.
 * [repmgr](https://github.com/2ndQuadrant/repmgr) - Open-source tool suite to manage replication and failover in a cluster of PostgreSQL servers.


### PR DESCRIPTION
From pgEdge, designed for advancing high-availability capabilities in Postgres and now open-sourced under the permissive PostgreSQL license.